### PR TITLE
Account for pre-normalized values

### DIFF
--- a/src/fields/PhoneNumberField.php
+++ b/src/fields/PhoneNumberField.php
@@ -60,6 +60,10 @@ class PhoneNumberField extends Field implements PreviewableFieldInterface
      */
     public function normalizeValue($value, ElementInterface $element = null)
     {
+        if ($value instanceof PhoneNumberModel) {
+            return $value;
+        }
+        
         if (is_string($value) && !empty($value)) {
             $value = Json::decodeIfJson($value);
         }


### PR DESCRIPTION
There are some cases where a pre-normalized value will be passed to `normalizeValue()`, so the method should be accounting for that.

Fixes #12